### PR TITLE
Feat/post

### DIFF
--- a/src/main/java/com/example/ottokeng/OttokengApplication.java
+++ b/src/main/java/com/example/ottokeng/OttokengApplication.java
@@ -2,7 +2,9 @@ package com.example.ottokeng;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OttokengApplication {
 

--- a/src/main/java/com/example/ottokeng/domain/post/entity/Post.java
+++ b/src/main/java/com/example/ottokeng/domain/post/entity/Post.java
@@ -35,6 +35,10 @@ public class Post extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Type type;
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
     public void update(String title, String contents, Get acquire, String image, String address, String communication, Type type){
         this.title = title;
         this.contents = contents;
@@ -45,7 +49,4 @@ public class Post extends BaseTimeEntity {
         this.type = type;
     }
 
-    @ManyToOne
-    @JoinColumn(name = "user")
-    private User user;
 }

--- a/src/main/java/com/example/ottokeng/domain/post/entity/Post.java
+++ b/src/main/java/com/example/ottokeng/domain/post/entity/Post.java
@@ -1,6 +1,7 @@
 package com.example.ottokeng.domain.post.entity;
 
 import com.example.ottokeng.domain.user.entity.User;
+import com.example.ottokeng.global.entity.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Post {
+public class Post extends BaseTimeEntity {
     @Id
     @GeneratedValue
     private Long id;
@@ -21,8 +22,6 @@ public class Post {
     private String title;
 
     private String contents;
-
-    private String date;
 
     @Enumerated(EnumType.STRING)
     private Get acquire;
@@ -36,10 +35,9 @@ public class Post {
     @Enumerated(EnumType.STRING)
     private Type type;
 
-    public void update(String title, String contents, String date, Get acquire, String image, String address, String communication, Type type){
+    public void update(String title, String contents, Get acquire, String image, String address, String communication, Type type){
         this.title = title;
         this.contents = contents;
-        this.date = date;
         this.acquire = acquire;
         this.image = image;
         this.address = address;

--- a/src/main/java/com/example/ottokeng/domain/post/presentation/dto/request/ModifyPostWritingRequest.java
+++ b/src/main/java/com/example/ottokeng/domain/post/presentation/dto/request/ModifyPostWritingRequest.java
@@ -12,8 +12,6 @@ import lombok.NoArgsConstructor;
 public class ModifyPostWritingRequest {
     private String title;
     private String contents;
-    private String name;
-    private String date;
     private Get acquire;
     private String image;
     private String address;

--- a/src/main/java/com/example/ottokeng/domain/post/presentation/dto/request/PostWritingRequest.java
+++ b/src/main/java/com/example/ottokeng/domain/post/presentation/dto/request/PostWritingRequest.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 public class PostWritingRequest {
     private String title;
     private String contents;
-    private String date;
     private Get acquire;
     private String image;
     private String address;

--- a/src/main/java/com/example/ottokeng/domain/post/presentation/dto/response/ShowPostResponse.java
+++ b/src/main/java/com/example/ottokeng/domain/post/presentation/dto/response/ShowPostResponse.java
@@ -19,15 +19,15 @@ public class ShowPostResponse {
     private String communication;
     private Type type;
 
-    public ShowPostResponse(Post lostWriting){
-        this.id = lostWriting.getId();
-        this.title = lostWriting.getTitle();
-        this.contents = lostWriting.getContents();
-        this.name = lostWriting.getUser().getName();
-        this.acquire = lostWriting.getAcquire();
-        this.image = lostWriting.getImage();
-        this.address = lostWriting.getAddress();
-        this.communication = lostWriting.getCommunication();
-        this.type = lostWriting.getType();
+    public ShowPostResponse(Post post){
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.contents = post.getContents();
+        this.name = post.getUser().getName();
+        this.acquire = post.getAcquire();
+        this.image = post.getImage();
+        this.address = post.getAddress();
+        this.communication = post.getCommunication();
+        this.type = post.getType();
     }
 }

--- a/src/main/java/com/example/ottokeng/domain/post/presentation/dto/response/ShowPostResponse.java
+++ b/src/main/java/com/example/ottokeng/domain/post/presentation/dto/response/ShowPostResponse.java
@@ -13,7 +13,6 @@ public class ShowPostResponse {
     private String title;
     private String contents;
     private String name;
-    private String date;
     private Get acquire;
     private String image;
     private String address;
@@ -25,7 +24,6 @@ public class ShowPostResponse {
         this.title = lostWriting.getTitle();
         this.contents = lostWriting.getContents();
         this.name = lostWriting.getUser().getName();
-        this.date = lostWriting.getDate();
         this.acquire = lostWriting.getAcquire();
         this.image = lostWriting.getImage();
         this.address = lostWriting.getAddress();

--- a/src/main/java/com/example/ottokeng/domain/post/presentation/dto/response/ShowPostResponse.java
+++ b/src/main/java/com/example/ottokeng/domain/post/presentation/dto/response/ShowPostResponse.java
@@ -6,6 +6,8 @@ import com.example.ottokeng.domain.post.entity.Type;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @AllArgsConstructor
 public class ShowPostResponse {
@@ -18,6 +20,7 @@ public class ShowPostResponse {
     private String address;
     private String communication;
     private Type type;
+    private LocalDateTime createdAt;
 
     public ShowPostResponse(Post post){
         this.id = post.getId();
@@ -29,5 +32,6 @@ public class ShowPostResponse {
         this.address = post.getAddress();
         this.communication = post.getCommunication();
         this.type = post.getType();
+        this.createdAt = post.getCreatedAt();
     }
 }

--- a/src/main/java/com/example/ottokeng/domain/post/presentation/dto/response/ShowPostResponse.java
+++ b/src/main/java/com/example/ottokeng/domain/post/presentation/dto/response/ShowPostResponse.java
@@ -22,11 +22,11 @@ public class ShowPostResponse {
     private Type type;
     private LocalDateTime createdAt;
 
-    public ShowPostResponse(Post post){
+    public ShowPostResponse(Post post, String name){
         this.id = post.getId();
         this.title = post.getTitle();
         this.contents = post.getContents();
-        this.name = post.getUser().getName();
+        this.name = name;
         this.acquire = post.getAcquire();
         this.image = post.getImage();
         this.address = post.getAddress();

--- a/src/main/java/com/example/ottokeng/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/example/ottokeng/domain/post/service/impl/PostServiceImpl.java
@@ -31,9 +31,11 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public AllPostsResponse getAllPost() {
+        User user = userUtil.getCurrentUser();
+
         List<ShowPostResponse> showPostResponses = postRepository.findAll()
                 .stream()
-                .map(ShowPostResponse::new)
+                .map(post -> new ShowPostResponse(post,user.getName()))
                 .collect(Collectors.toList());
         return AllPostsResponse.builder()
                 .list(showPostResponses)
@@ -53,6 +55,8 @@ public class PostServiceImpl implements PostService {
                 .type(request.getType())
                 .user(user)
                 .build();
+
+        user.getPosts().add(post);
 
         postRepository.save(post);
     }

--- a/src/main/java/com/example/ottokeng/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/example/ottokeng/domain/post/service/impl/PostServiceImpl.java
@@ -46,7 +46,6 @@ public class PostServiceImpl implements PostService {
         Post post = Post.builder()
                 .title(request.getTitle())
                 .contents(request.getContents())
-                .date(request.getDate())
                 .image(request.getImage())
                 .acquire(request.getAcquire())
                 .address(request.getAddress())
@@ -67,7 +66,6 @@ public class PostServiceImpl implements PostService {
         post.update(
                 request.getTitle(),
                 request.getContents(),
-                request.getDate(),
                 request.getAcquire(),
                 request.getImage(),
                 request.getAddress(),

--- a/src/main/java/com/example/ottokeng/domain/user/entity/User.java
+++ b/src/main/java/com/example/ottokeng/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -32,7 +33,7 @@ public class User {
     private Role role;
 
     @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "user")
-    private List<Post> posts;
+    private List<Post> posts = new ArrayList<>();
 
     public User update(String name, String imageUrl) {
         this.name = name;

--- a/src/main/java/com/example/ottokeng/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/ottokeng/global/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.example.ottokeng.global.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+}

--- a/src/main/java/com/example/ottokeng/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/ottokeng/global/entity/BaseTimeEntity.java
@@ -17,9 +17,9 @@ public class BaseTimeEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdDate;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime modifiedDate;
+    private LocalDateTime modifiedAt;
 
 }


### PR DESCRIPTION
## 개요 😫

 Post엔티티에 생성날짜 추가

## 작업내용 🐉

기존에 존재하던 수동으로 날짜를 받던 date필드를 삭제하고 @CreatedDate와 @LastModifiedDate를 사용하여 작성일과 수정일을 Post엔티티에 저장하였습니다.  

글 전체 목록을 반환하는 dto에 createdAt필드를 추가하였습니다.
